### PR TITLE
Include all cookies on Authentication

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,13 +46,9 @@ export async function checkSession(response) {
     };
 
     var raw_cookies = await browser.cookies.getAll({"domain":"google.com"});
+    var ghunt_cookies = Object.fromEntries(raw_cookies.map(x => [x.name, x.value]));
 
-    var wanted = ["SID", "SSID", "APISID", "SAPISID", "HSID", "LSID", "__Secure-3PSID", "oauth_token"];
-
-    var ghunt_cookies = raw_cookies.filter(function(obj) {return wanted.includes(obj.name)});
-    ghunt_cookies = Object.fromEntries(ghunt_cookies.map(x => [x.name, x.value]));
-
-    if (Object.keys(ghunt_cookies).length >= wanted.length && (response.statusCode == 200 || response.ok)) {
+    if ((response.statusCode == 200 || response.ok)) {
         console.log("Connected ! Putting data in storage...");
         await browser.storage.local.set({"ghunt": {
             "cookies": ghunt_cookies,


### PR DESCRIPTION
Looks like there are some changes in Google Authentication in the end of the year, and now GHunt does not work.
I've investigated the issue and found that passing all cookies will work.
Here, I modified the code to include all cookies.

I'll also submit a PR to mxrch/GHunt along with this.